### PR TITLE
fix(spawn): use cross-spawn-async to launch commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "check-coverage": "istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "report-coverage": "cat ./coverage/lcov.info | codecov",
     "test:watch": "mocha src/*.test.js -w --compilers js:babel/register",
-    "test": "istanbul cover -x *.test.js _mocha -- -R spec src/index.test.js --compilers js:babel/register",
+    "test": "istanbul cover -x *.test.js node_modules/mocha/bin/_mocha -- -R spec src/index.test.js --compilers js:babel/register",
     "prepublish": "npm run build",
     "postpublish": "publish-latest",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
@@ -39,6 +39,7 @@
     "chai": "3.3.0",
     "codecov.io": "0.1.6",
     "commitizen": "1.0.5",
+    "cross-spawn-async": "^2.0.0",
     "cz-conventional-changelog": "1.1.2",
     "eslint": "1.5.1",
     "eslint-config-kentcdodds": "4.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import {spawn} from 'child_process';
+import spawn from 'cross-spawn-async';
 import getPathVar from 'add-to-path/dist/get-path-var';
 export default crossEnv;
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -7,17 +7,17 @@ chai.use(sinonChai);
 
 const {expect} = chai;
 const proxied = {
-  child_process: { // eslint-disable-line camelcase
-    spawn: sinon.spy(() => 'spawn-returned')
-  }
+  spawn: sinon.spy(() => 'spawn-returned')
 };
 
-const crossEnv = proxyquire('./index', proxied);
+const crossEnv = proxyquire('./index', {
+  'cross-spawn-async': proxied.spawn
+});
 
 describe(`cross-env`, () => {
 
   beforeEach(() => {
-    proxied.child_process.spawn.reset();
+    proxied.spawn.reset();
   });
 
   it(`should set environment variables and run the remaining command`, () => {
@@ -30,7 +30,7 @@ describe(`cross-env`, () => {
 
   it(`should do nothing given no command`, () => {
     crossEnv([]);
-    expect(proxied.child_process.spawn).to.have.not.been.called;
+    expect(proxied.spawn).to.have.not.been.called;
   });
 
   function testEnvSetting(...envSettings) {
@@ -42,8 +42,8 @@ describe(`cross-env`, () => {
     });
 
     expect(ret, 'returns what spawn returns').to.equal('spawn-returned');
-    expect(proxied.child_process.spawn).to.have.been.calledOnce;
-    expect(proxied.child_process.spawn).to.have.been.calledWith(
+    expect(proxied.spawn).to.have.been.calledOnce;
+    expect(proxied.spawn).to.have.been.calledWith(
       'echo', ['hello world'], {stdio: 'inherit', env}
     );
   }


### PR DESCRIPTION
ref: nodejs/node-v0.x-archive#2318

When running `npm i` in the angular-formly repo the output is

```
> cross-env NODE_ENV=production webpack --progress --colors

events.js:141
      throw er; // Unhandled 'error' event
      ^

Error: spawn webpack ENOENT
    at exports._errnoException (util.js:849:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:178:32)
    at onErrorNT (internal/child_process.js:344:16)
    at doNTCallback2 (node.js:430:9)
    at process._tickCallback (node.js:344:17)
    at Function.Module.runMain (module.js:477:11)
    at startup (node.js:118:18)
    at node.js:952:3
```