### PR TITLE
fix(env): checks if windows platform, then send in APPDATA env var.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     }
   },
   "dependencies": {
-    "cross-spawn": "2.0.0",
+    "cross-spawn-async": "2.0.0",
     "manage-path": "2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "check-coverage": "istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "report-coverage": "cat ./coverage/lcov.info | codecov",
     "test:watch": "mocha src/*.test.js -w --compilers js:babel/register",
-    "test": "istanbul cover -x *.test.js _mocha -- -R spec src/index.test.js --compilers js:babel/register",
+    "test": "istanbul cover -x *.test.js node_modules/mocha/bin/_mocha -- -R spec src/index.test.js --compilers js:babel/register",
     "prepublish": "npm run build",
     "postpublish": "publish-latest",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ function getCommandArgsAndEnvVars(args) {
       command = shifted;
       break;
     }
+    /* istanbul ignore else  */
     if (process.platform === 'win32') {
       envVars.APPDATA = process.env.APPDATA;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -24,10 +24,7 @@ function getCommandArgsAndEnvVars(args) {
       command = shifted;
       break;
     }
-    /* istanbul ignore else  */
-    if (process.platform === 'win32') {
-      envVars.APPDATA = process.env.APPDATA;
-    }
+    envVars.APPDATA = process.env.APPDATA;
   }
   return [command, commandArgs, envVars];
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import {spawn} from 'cross-spawn';
+import {spawn} from 'cross-spawn-async';
 import getPathVar from 'manage-path/dist/get-path-var';
 export default crossEnv;
 
@@ -23,6 +23,9 @@ function getCommandArgsAndEnvVars(args) {
     } else {
       command = shifted;
       break;
+    }
+    if (process.platform === 'win32') {
+      envVars.APPDATA = process.env.APPDATA;
     }
   }
   return [command, commandArgs, envVars];

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -7,7 +7,7 @@ chai.use(sinonChai);
 
 const {expect} = chai;
 const proxied = {
-  'cross-spawn': {
+  'cross-spawn-async': {
     spawn: sinon.spy(() => 'spawn-returned')
   }
 };
@@ -17,7 +17,7 @@ const crossEnv = proxyquire('./index', proxied);
 describe(`cross-env`, () => {
 
   beforeEach(() => {
-    proxied['cross-spawn'].spawn.reset();
+    proxied['cross-spawn-async'].spawn.reset();
   });
 
   it(`should set environment variables and run the remaining command`, () => {
@@ -30,20 +30,23 @@ describe(`cross-env`, () => {
 
   it(`should do nothing given no command`, () => {
     crossEnv([]);
-    expect(proxied['cross-spawn'].spawn).to.have.not.been.called;
+    expect(proxied['cross-spawn-async'].spawn).to.have.not.been.called;
   });
 
   function testEnvSetting(...envSettings) {
     const ret = crossEnv([...envSettings, 'echo', 'hello world']);
     const env = {[getPathVar()]: process.env[getPathVar()]};
+    if (process.platform === 'win32') {
+      env.APPDATA = process.env.APPDATA;
+    }
     envSettings.forEach(setting => {
       const [prop, val] = setting.split('=');
       env[prop] = val;
     });
 
     expect(ret, 'returns what spawn returns').to.equal('spawn-returned');
-    expect(proxied['cross-spawn'].spawn).to.have.been.calledOnce;
-    expect(proxied['cross-spawn'].spawn).to.have.been.calledWith(
+    expect(proxied['cross-spawn-async'].spawn).to.have.been.calledOnce;
+    expect(proxied['cross-spawn-async'].spawn).to.have.been.calledWith(
       'echo', ['hello world'], {stdio: 'inherit', env}
     );
   }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -36,9 +36,7 @@ describe(`cross-env`, () => {
   function testEnvSetting(...envSettings) {
     const ret = crossEnv([...envSettings, 'echo', 'hello world']);
     const env = {[getPathVar()]: process.env[getPathVar()]};
-    if (process.platform === 'win32') {
-      env.APPDATA = process.env.APPDATA;
-    }
+    env.APPDATA = process.env.APPDATA;
     envSettings.forEach(setting => {
       const [prop, val] = setting.split('=');
       env[prop] = val;


### PR DESCRIPTION
Checks if the platform is windows. If it is, adds the process.env.APPDATA var to the options sent into ```spawn```.

Also opted for ```cross-spawn-async``` as it is the core of cross-spawn, and the other package is only for added spawnSync support, which is not used here.