### PR TITLE
Merge with original environment instead of defining a new one

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-plugin-mocha": "1.0.0",
     "ghooks": "1.0.0",
     "istanbul": "0.3.21",
+    "manage-path": "2.0.0",
     "mocha": "2.3.3",
     "proxyquire": "1.7.2",
     "publish-latest": "1.1.2",
@@ -64,6 +65,6 @@
   },
   "dependencies": {
     "cross-spawn-async": "2.0.0",
-    "manage-path": "2.0.0"
+    "lodash.assign": "^3.2.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import {spawn} from 'cross-spawn-async';
-import getPathVar from 'manage-path/dist/get-path-var';
+import assign from 'lodash.assign';
 export default crossEnv;
 
 const envSetterRegex = /(\w+)=(\w+)/;
@@ -13,7 +13,7 @@ function crossEnv(args) {
 
 function getCommandArgsAndEnvVars(args) {
   let command;
-  const envVars = {[getPathVar()]: process.env[getPathVar()]};
+  const envVars = assign({}, process.env);
   const commandArgs = args.slice();
   while (commandArgs.length) {
     const shifted = commandArgs.shift();

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -3,6 +3,7 @@ import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
 import proxyquire from 'proxyquire';
 import getPathVar from 'manage-path/dist/get-path-var';
+import assign from 'lodash.assign';
 chai.use(sinonChai);
 
 const {expect} = chai;
@@ -45,7 +46,7 @@ describe(`cross-env`, () => {
     expect(ret, 'returns what spawn returns').to.equal('spawn-returned');
     expect(proxied['cross-spawn-async'].spawn).to.have.been.calledOnce;
     expect(proxied['cross-spawn-async'].spawn).to.have.been.calledWith(
-      'echo', ['hello world'], {stdio: 'inherit', env}
+      'echo', ['hello world'], {stdio: 'inherit', env: assign({}, process.env, env)}
     );
   }
 });


### PR DESCRIPTION
When you use ``cross-env`` you will lose any original env variable, which includes not being able to 

* run ``DEBUG=* npm run a-script-using-cross-env``
* use ``process.env.npm_package_config_MY_CONFIG`` instead a npm script using cross-env

Those use cases are quite common, so I suggest with this PR that ``cross-env`` does not **initialize** a whole new env, but **merges** with existing one.