### PR TITLE
fix(lib): Handle special characters and quoted strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import {spawn} from 'cross-spawn-async';
 import assign from 'lodash.assign';
 export default crossEnv;
 
-const envSetterRegex = /(\w+)=(\w+)/;
+const envSetterRegex = /(\w+)=('(.+)'|"(.+)"|(.+))/;
 
 function crossEnv(args) {
   const [command, commandArgs, env] = getCommandArgsAndEnvVars(args);
@@ -19,7 +19,7 @@ function getCommandArgsAndEnvVars(args) {
     const shifted = commandArgs.shift();
     const match = envSetterRegex.exec(shifted);
     if (match) {
-      envVars[match[1]] = match[2];
+      envVars[match[1]] = match[3] || match[4] || match[5];
     } else {
       command = shifted;
       break;


### PR DESCRIPTION
This fixes #6. I also added handling of quoted strings. Since `split` in the tests doesn't work correctly when a quoted strings contains equality signs, I made the expected environment explicit (mostly because the "correct" regex has quite some logic in it).

Happy :christmas_tree: :smiley: 