### PR TITLE
fix(spawn): Propagate spawned process exit code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,9 @@ const envSetterRegex = /(\w+)=('(.+)'|"(.+)"|(.+))/;
 function crossEnv(args) {
   const [command, commandArgs, env] = getCommandArgsAndEnvVars(args);
   if (command) {
-    return spawn(command, commandArgs, {stdio: 'inherit', env});
+    const proc = spawn(command, commandArgs, {stdio: 'inherit', env});
+    proc.on('exit', process.exit);
+    return proc;
   }
 }
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -7,9 +7,10 @@ import assign from 'lodash.assign';
 chai.use(sinonChai);
 
 const {expect} = chai;
+const spawned = {on: sinon.spy()};
 const proxied = {
   'cross-spawn-async': {
-    spawn: sinon.spy(() => 'spawn-returned')
+    spawn: sinon.spy(() => spawned)
   }
 };
 
@@ -19,6 +20,7 @@ describe(`cross-env`, () => {
 
   beforeEach(() => {
     proxied['cross-spawn-async'].spawn.reset();
+    spawned.on.reset();
   });
 
   it(`should set environment variables and run the remaining command`, () => {
@@ -69,7 +71,7 @@ describe(`cross-env`, () => {
     env.APPDATA = process.env.APPDATA;
     assign(env, expected);
 
-    expect(ret, 'returns what spawn returns').to.equal('spawn-returned');
+    expect(ret, 'returns what spawn returns').to.equal(spawned);
     expect(proxied['cross-spawn-async'].spawn).to.have.been.calledOnce;
     expect(proxied['cross-spawn-async'].spawn).to.have.been.calledWith(
       'echo', ['hello world'], {
@@ -77,5 +79,8 @@ describe(`cross-env`, () => {
         env: assign({}, process.env, env)
       }
     );
+
+    expect(spawned.on).to.have.been.calledOnce;
+    expect(spawned.on).to.have.been.calledWith('exit');
   }
 });


### PR DESCRIPTION
Exit codes are swallowed at the moment. So if I run tests and they fail, I still get `0` exit code.

Here is the problem:

<img width="653" alt="20160103-203522" src="https://cloud.githubusercontent.com/assets/175264/12078247/19fd131a-b25e-11e5-9ea7-45ca3bee16a9.png">


Fixed behaviour:

<img width="713" alt="20160103-210631" src="https://cloud.githubusercontent.com/assets/175264/12078249/250b04b0-b25e-11e5-88ac-56b8389de863.png">



My test file:

```js
'use strict';

process.on('uncaughtException', err => {
  console.error(err);
  console.log(err.stack);
  process.exit(1);
});

throw new Error('OMG!');
```