### PR TITLE
fix broken tests in windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "eslint-plugin-mocha": "1.0.0",
     "ghooks": "1.0.0",
     "istanbul": "0.3.21",
-    "manage-path": "2.0.0",
     "mocha": "2.3.3",
     "proxyquire": "1.7.2",
     "rimraf": "^2.5.2",

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -2,7 +2,6 @@ import chai from 'chai';
 import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
 import proxyquire from 'proxyquire';
-import getPathVar from 'manage-path/dist/get-path-var';
 import assign from 'lodash.assign';
 chai.use(sinonChai);
 
@@ -59,7 +58,6 @@ describe(`cross-env`, () => {
       FOO_ENV: 'foo=bar'
     }, 'FOO_ENV="foo=bar"');
   });
-
   it(`should do nothing given no command`, () => {
     crossEnv([]);
     expect(proxied['cross-spawn'].spawn).to.have.not.been.called;
@@ -67,7 +65,7 @@ describe(`cross-env`, () => {
 
   function testEnvSetting(expected, ...envSettings) {
     const ret = crossEnv([...envSettings, 'echo', 'hello world']);
-    const env = {[getPathVar()]: process.env[getPathVar()]};
+    const env = {};
     env.APPDATA = process.env.APPDATA;
     assign(env, expected);
 


### PR DESCRIPTION
when running npm test on windows, a "PATH" variable was added to the environment while in windows the path variable is "Path".
This caused two path variables in the env object in the tests, which caused the expected and actual results to diverge.

Since the use of `getPathVar` was removed from the lib in previous commits, I thought it ok to remove it's use in the test cases.