### PR TITLE
support multi-value enviornment variables with the -m flag

### DIFF
--- a/other/src.eslintrc
+++ b/other/src.eslintrc
@@ -2,5 +2,8 @@
   "extends": "kentcdodds",
   "env": {
     "browser": false
+  },
+  "rules": {
+    "complexity": [1, 6]
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "eslint-plugin-mocha": "1.0.0",
     "ghooks": "1.0.0",
     "istanbul": "0.3.21",
-    "manage-path": "2.0.0",
     "mocha": "2.3.3",
     "proxyquire": "1.7.2",
     "rimraf": "^2.5.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import {spawn} from 'cross-spawn';
 import assign from 'lodash.assign';
+import path from 'path';
 export default crossEnv;
 
 const envSetterRegex = /(\w+)=('(.+)'|"(.+)"|(.+))/;
@@ -17,11 +18,18 @@ function getCommandArgsAndEnvVars(args) {
   let command;
   const envVars = assign({}, process.env);
   const commandArgs = args.slice();
+  let isMultiValue = false;
   while (commandArgs.length) {
     const shifted = commandArgs.shift();
     const match = envSetterRegex.exec(shifted);
     if (match) {
       envVars[match[1]] = match[3] || match[4] || match[5];
+      if (isMultiValue) {
+        envVars[match[1]] = envVars[match[1]].replace(/:/g, path.delimiter);
+        isMultiValue = false;
+      }
+    } else if (shifted === '-m') {
+      isMultiValue = true;
     } else {
       command = shifted;
       break;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -2,7 +2,6 @@ import chai from 'chai';
 import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
 import proxyquire from 'proxyquire';
-import getPathVar from 'manage-path/dist/get-path-var';
 import assign from 'lodash.assign';
 chai.use(sinonChai);
 
@@ -59,7 +58,6 @@ describe(`cross-env`, () => {
       FOO_ENV: 'foo=bar'
     }, 'FOO_ENV="foo=bar"');
   });
-
   it(`should do nothing given no command`, () => {
     crossEnv([]);
     expect(proxied['cross-spawn'].spawn).to.have.not.been.called;
@@ -67,7 +65,7 @@ describe(`cross-env`, () => {
 
   function testEnvSetting(expected, ...envSettings) {
     const ret = crossEnv([...envSettings, 'echo', 'hello world']);
-    const env = {[getPathVar()]: process.env[getPathVar()]};
+    const env = {};
     env.APPDATA = process.env.APPDATA;
     assign(env, expected);
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -10,6 +10,9 @@ const spawned = {on: sinon.spy()};
 const proxied = {
   'cross-spawn': {
     spawn: sinon.spy(() => spawned)
+  },
+  path: {
+    delimiter: '@'
   }
 };
 
@@ -57,6 +60,16 @@ describe(`cross-env`, () => {
     testEnvSetting({
       FOO_ENV: 'foo=bar'
     }, 'FOO_ENV="foo=bar"');
+  });
+  it('should change delimiter to match platform\'s if multi-value flag is set', () => {
+    testEnvSetting({
+      FOO_ENV: 'foo@bar'
+    }, '-m', 'FOO_ENV=foo:bar');
+  });
+  it('should not change delimiter if multi-value flag is not set', () => {
+    testEnvSetting({
+      FOO_ENV: 'foo:bar'
+    }, 'FOO_ENV=foo:bar');
   });
   it(`should do nothing given no command`, () => {
     crossEnv([]);


### PR DESCRIPTION
fixes #17

I've changed the eslint complexity rule to a warning since I did not want to refactor the `getCommandArgsAndEnvVars` to have a lower complexity (which would require me to make a considerable redesign).