### PR TITLE
feat(kill): Propagate SIGTERM to created process

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ function crossEnv(args) {
   const [command, commandArgs, env] = getCommandArgsAndEnvVars(args);
   if (command) {
     const proc = spawn(command, commandArgs, {stdio: 'inherit', env});
+    process.on('SIGTERM', () => proc.kill('SIGTERM'));
     proc.on('exit', process.exit);
     return proc;
   }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -6,7 +6,7 @@ import assign from 'lodash.assign';
 chai.use(sinonChai);
 
 const {expect} = chai;
-const spawned = {on: sinon.spy()};
+const spawned = {on: sinon.spy(), kill: sinon.spy()};
 const proxied = {
   'cross-spawn': {
     spawn: sinon.spy(() => spawned)
@@ -58,9 +58,19 @@ describe(`cross-env`, () => {
       FOO_ENV: 'foo=bar'
     }, 'FOO_ENV="foo=bar"');
   });
+
   it(`should do nothing given no command`, () => {
     crossEnv([]);
     expect(proxied['cross-spawn'].spawn).to.have.not.been.called;
+  });
+
+  it(`should propage SIGTERM signal`, () => {
+    testEnvSetting({
+      FOO_ENV: 'foo=bar'
+    }, 'FOO_ENV="foo=bar"');
+
+    process.emit('SIGTERM');
+    expect(spawned.kill).to.have.been.calledWith('SIGTERM');
   });
 
   function testEnvSetting(expected, ...envSettings) {


### PR DESCRIPTION
I'm using cross-env with [concurrently](https://github.com/kimmobrunfeldt/concurrently). There is a option to kill other processes when one of them exit. But the process using cross-env never exit, because the SIGTERM is not propagated to the child process. This PR fix this issue.