### PR TITLE
feat(vars): Convert environment vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "check-coverage": "istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "report-coverage": "cat ./coverage/lcov.info | codecov",
     "test:watch": "mocha src/*.test.js -w --compilers js:babel/register",
-    "test": "istanbul cover -x *.test.js node_modules/mocha/bin/_mocha -- -R spec src/index.test.js --compilers js:babel/register",
+    "test": "istanbul cover -x *.test.js node_modules/mocha/bin/_mocha -- -R spec src/*.test.js --compilers js:babel/register",
     "prepublish": "npm run build",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },

--- a/src/command.js
+++ b/src/command.js
@@ -1,0 +1,19 @@
+export default commandConvert;
+
+const envUseUnixRegex = /\$(\w+)/g; // $my_var
+const envUseWinRegex = /\%(.*?)\%/g; // %my_var%
+const isWin = process.platform === 'win32';
+const envExtract = isWin ? envUseUnixRegex : envUseWinRegex;
+
+/**
+ * Converts an environment variable usage to be appropriate for the current OS
+ * @param {String} command Command to convert
+ * @returns {String} Converted command
+ */
+function commandConvert(command) {
+  const match = envExtract.exec(command);
+  if (match) {
+    command = isWin ? `%${match[1]}%` : `$${match[1]}`;
+  }
+  return command;
+}

--- a/src/command.test.js
+++ b/src/command.test.js
@@ -1,0 +1,50 @@
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+import proxyquire from 'proxyquire';
+chai.use(sinonChai);
+
+const {expect} = chai;
+
+describe(`commandConvert`, () => {
+  const platform = process.platform;
+  let commandConvert;
+
+  describe(`on Windows`, () =>{
+    beforeEach(() =>{
+      Object.defineProperty(process, 'platform', {value: 'win32'});
+      commandConvert = proxyquire('./command', {});
+    });
+
+    afterEach(() =>{
+      Object.defineProperty(process, 'platform', {value: platform});
+    });
+
+    it(`should convert unix-style env variable usage for windows`, () =>{
+      expect(commandConvert('$test')).to.equal('%test%');
+    });
+
+    it(`should leave command unchanged when not a variable`, () =>{
+      expect(commandConvert('test')).to.equal('test');
+    });
+  });
+
+  describe(`on Unix-based`, () =>{
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', {value: 'linux'});
+      commandConvert = proxyquire('./command', {});
+    });
+
+    afterEach(() =>{
+      Object.defineProperty(process, 'platform', {value: platform});
+    });
+
+    it(`should convert windows-style env variable usage for linux`, () =>{
+      expect(commandConvert('%test%')).to.equal('$test');
+    });
+
+    it(`should leave variable unchanged when using correct operating system`, () =>{
+      expect(commandConvert('$test')).to.equal('$test');
+    });
+  });
+
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import {spawn} from 'cross-spawn';
+import commandConvert from './command';
 export default crossEnv;
 
 const envSetterRegex = /(\w+)=('(.+)'|"(.+)"|(.+))/;
@@ -16,7 +17,7 @@ function crossEnv(args) {
 function getCommandArgsAndEnvVars(args) { // eslint-disable-line
   let command;
   const envVars = Object.assign({}, process.env);
-  const commandArgs = args.slice();
+  const commandArgs = args.slice().map(commandConvert);
   while (commandArgs.length) {
     const shifted = commandArgs.shift();
     const match = envSetterRegex.exec(shifted);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -2,7 +2,6 @@ import chai from 'chai';
 import sinonChai from 'sinon-chai';
 import sinon from 'sinon';
 import proxyquire from 'proxyquire';
-import assign from 'lodash.assign';
 chai.use(sinonChai);
 
 const {expect} = chai;
@@ -93,13 +92,13 @@ describe(`cross-env`, () => {
     if (process.env.APPDATA) {
       env.APPDATA = process.env.APPDATA;
     }
-    assign(env, expected);
+    Object.assign(env, expected);
     expect(ret, 'returns what spawn returns').to.equal(spawned);
     expect(proxied['cross-spawn'].spawn).to.have.been.calledOnce;
     expect(proxied['cross-spawn'].spawn).to.have.been.calledWith(
       'echo', ['hello world'], {
         stdio: 'inherit',
-        env: assign({}, process.env, env)
+        env: Object.assign({}, process.env, env)
       }
     );
 


### PR DESCRIPTION
- Converts environment vars used in `npm run` to account for windows/linux respectively
- Add tests for command
- Update `npm test` to look for all .test.js files

Essentially it makes `cross-env PORT=3000 $npm_package_main` work, otherwise on Windows you get `Error: Cannot find module 'C:\Repo\$npm_package_main'` since Windows expects env variables to be in the format of `%npm_package_main%`


As a side note, the `linebreak-style` rule makes it a frustrating experience committing against the repo as it fails all commits despite the fact that Git converts `CRLF` to `LF` automatically on commit (this is a default setting for Git on Windows)