### PR TITLE
fix(kill): Add all kill signals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,9 @@ function crossEnv(args) {
   if (command) {
     const proc = spawn(command, commandArgs, {stdio: 'inherit', env});
     process.on('SIGTERM', () => proc.kill('SIGTERM'));
+    process.on('SIGINT', () => proc.kill('SIGINT'));
+    process.on('SIGBREAK', () => proc.kill('SIGBREAK'));
+    process.on('SIGHUP', () => proc.kill('SIGHUP'));
     proc.on('exit', process.exit);
     return proc;
   }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -71,13 +71,19 @@ describe(`cross-env`, () => {
     expect(proxied['cross-spawn'].spawn).to.have.not.been.called;
   });
 
-  it(`should propage SIGTERM signal`, () => {
+  it(`should propagate kill signals`, () => {
     testEnvSetting({
       FOO_ENV: 'foo=bar'
     }, 'FOO_ENV="foo=bar"');
 
     process.emit('SIGTERM');
+    process.emit('SIGINT');
+    process.emit('SIGHUP');
+    process.emit('SIGBREAK');
     expect(spawned.kill).to.have.been.calledWith('SIGTERM');
+    expect(spawned.kill).to.have.been.calledWith('SIGINT');
+    expect(spawned.kill).to.have.been.calledWith('SIGHUP');
+    expect(spawned.kill).to.have.been.calledWith('SIGBREAK');
   });
 
   function testEnvSetting(expected, ...envSettings) {


### PR DESCRIPTION
- Adds the 4 main kill signals that NodeJS handles
- Add tests for kill signals, update test description


I couldn't get a loop over the event names to work for some reason, so ended up just hard coding them all

Satisfies #31 for my uses