### PR TITLE
Enforce minimum Node.js version requirement using 'engines' attribute package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Status:
 
 This micro-lib allows you to provide a script which sets an environment using unix style and have it work on windows too
 
+## Prerequisites
+-   [Node.js](https://nodejs.org/) version 4.0 or greater.
+
 ## Usage
 
 I use this in my npm scripts:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "cross-env": "bin/cross-env.js"
   },
+  "engines": {
+    "node" : ">=4.0"
+  },
   "scripts": {
     "start": "npm run test:watch",
     "prebuild": "rimraf dist && mkdir dist",


### PR DESCRIPTION
Since the cross-env can only support Node.js version 4.0 or greater as of [cross-env version 3.0.0](https://github.com/kentcdodds/cross-env/releases/tag/v3.0.0), I added an `engines` attribute to `package.json` which will enforce the presence of Node.js version 4.0 or greater. If someone tries to run/build cross-env with an older version of Node.js, the `engines` attribute will cause an error to be thrown as soon as they try to run `npm install` (or otherwise try to run/build the project).

In addition, I also added a **`Prerequisites`** section to `README.md` which states that Node.js version 4.0 or greater is required.