### PR TITLE
feat(append): Added ability to append to environment variable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import {spawn} from 'cross-spawn';
 import commandConvert from './command';
 export default crossEnv;
 
-const envSetterRegex = /(\w+)=('(.+)'|"(.+)"|(.+))/;
+const envSetterRegex = /(\w+)(\+?=)(?:'(.+)'|"(.+)"|(.+))/;
 
 function crossEnv(args) {
   const [command, commandArgs, env] = getCommandArgsAndEnvVars(args);
@@ -25,7 +25,14 @@ function getCommandArgsAndEnvVars(args) { // eslint-disable-line
     const shifted = commandArgs.shift();
     const match = envSetterRegex.exec(shifted);
     if (match) {
-      envVars[match[1]] = match[3] || match[4] || match[5];
+      const name = match[1];
+      const operator = match[2];
+      const value = match[3] || match[4] || match[5];
+      if (operator === '+=') {
+        envVars[name] = process.env[name] + value;
+      } else {
+        envVars[name] = value;
+      }
     } else {
       command = shifted;
       break;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -27,6 +27,13 @@ describe(`cross-env`, () => {
     }, 'FOO_ENV=production');
   });
 
+  it(`should append to environment variables and run the remaining command`, () => {
+    process.env.FOO_ENV = 'production';
+    testEnvSetting({
+      FOO_ENV: 'production:test'
+    }, 'FOO_ENV+=:test');
+  });
+
   it(`should APPDATA be undefined and not string`, () => {
     testEnvSetting({
       FOO_ENV: 'production',


### PR DESCRIPTION
This is a small change that adds the `+=` operator for appending to an environment variable.

For example:
```
cross-env PATH+=/usr/local/random-app/bin
```

I'll personally be using this for `NODE_PATH` in unit tests, but it could be useful for modifying `PATH`, `DEBUG` or other environment variables that contain a delimited set of entries.

Edit: I actually make this change before noticing the cross-var documentation update 6 days ago. I'll close this PR.