### PR TITLE
fix: addContributor script does not need usename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ This project follows the [all contributors][all-contributors] specification. To 
 contributors on the README.md, please use the automated script as part of your PR:
 
 ```console
-npm start addContributor <YOUR_GITHUB_USERNAME>
+npm start addContributor
 ```
 
 Follow the prompt. If you've already added yourself to the list and are making a new type of contribution, you can run


### PR DESCRIPTION
if execute like `npm start addContributor zhuangya` would receive:

```
npm ERR! cross-env@0.0.0-semantically-released start: `nps "addContributor" "zhuangya"`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the cross-env@0.0.0-semantically-released start script 'nps "addContributor" "zhuangya"'.
```