### PR TITLE
fix: update path to release page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # CHANGELOG
 
 The changelog is automatically updated using [semantic-release](https://github.com/semantic-release/semantic-release).
-You can see it on the [releases page](../releases).
+You can see it on the [releases page](../../releases).


### PR DESCRIPTION
Need to go up 2 directories to get out of `/blob/`, as currently the link will try sending you to `https://github.com/kentcdodds/cross-env/blob/releases` - which doesn't exist.

