### PR TITLE
feat(args): convert embedded and braced variables in command args

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -2,15 +2,14 @@ import isWindows from 'is-windows'
 
 export default commandConvert
 
-const envUseUnixRegex = /\$(\w+)|\${(\w+)}/g // $my_var or ${my_var}
-const envUseWinRegex = /%(.*?)%/g // %my_var%
-
 /**
  * Converts an environment variable usage to be appropriate for the current OS
  * @param {String} command Command to convert
  * @returns {String} Converted command
  */
 function commandConvert(command) {
+  const envUseUnixRegex = /\$(\w+)|\${(\w+)}/g // $my_var or ${my_var}
+  const envUseWinRegex = /%(.*?)%/g // %my_var%
   const isWin = isWindows()
   const envExtract = isWin ? envUseUnixRegex : envUseWinRegex
   return command.replace(envExtract, isWin ? '%$1$2%' : '$$$1')

--- a/src/command.js
+++ b/src/command.js
@@ -13,9 +13,5 @@ const envUseWinRegex = /%(.*?)%/ // %my_var%
 function commandConvert(command) {
   const isWin = isWindows()
   const envExtract = isWin ? envUseUnixRegex : envUseWinRegex
-  const match = envExtract.exec(command)
-  if (match) {
-    command = isWin ? `%${match[1]}%` : `$${match[1]}`
-  }
-  return command
+  return command.replace(envExtract, isWin ? '%$1%' : '$$$1')
 }

--- a/src/command.js
+++ b/src/command.js
@@ -2,8 +2,8 @@ import isWindows from 'is-windows'
 
 export default commandConvert
 
-const envUseUnixRegex = /\$(\w+)/ // $my_var
-const envUseWinRegex = /%(.*?)%/ // %my_var%
+const envUseUnixRegex = /\$(\w+)|\${(\w+)}/g // $my_var or ${my_var}
+const envUseWinRegex = /%(.*?)%/g // %my_var%
 
 /**
  * Converts an environment variable usage to be appropriate for the current OS
@@ -13,5 +13,5 @@ const envUseWinRegex = /%(.*?)%/ // %my_var%
 function commandConvert(command) {
   const isWin = isWindows()
   const envExtract = isWin ? envUseUnixRegex : envUseWinRegex
-  return command.replace(envExtract, isWin ? '%$1%' : '$$$1')
+  return command.replace(envExtract, isWin ? '%$1$2%' : '$$$1')
 }

--- a/src/command.test.js
+++ b/src/command.test.js
@@ -30,3 +30,24 @@ test(`is stateless`, () => {
   isWindowsMock.__mock.returnValue = true
   expect(commandConvert('$test')).toBe(commandConvert('$test'))
 })
+
+test(`converts embedded unix-style env variables usage for windows`, () => {
+  isWindowsMock.__mock.returnValue = true
+  expect(commandConvert('$test1/$test2/$test3')).toBe(
+    '%test1%/%test2%/%test3%',
+  )
+})
+
+test(`converts embedded windows-style env variables usage for linux`, () => {
+  isWindowsMock.__mock.returnValue = false
+  expect(commandConvert('%test1%/%test2%/%test3%')).toBe(
+    '$test1/$test2/$test3',
+  )
+})
+
+test(`
+  leaves embedded variables unchanged 
+  when using correct operating system`, () => {
+  isWindowsMock.__mock.returnValue = false
+  expect(commandConvert('$test1/$test2/$test3')).toBe('$test1/$test2/$test3')
+})

--- a/src/command.test.js
+++ b/src/command.test.js
@@ -45,9 +45,8 @@ test(`converts embedded windows-style env variables usage for linux`, () => {
   )
 })
 
-test(`
-  leaves embedded variables unchanged 
-  when using correct operating system`, () => {
+// eslint-disable-next-line max-len
+test(`leaves embedded variables unchanged when using correct operating system`, () => {
   isWindowsMock.__mock.returnValue = false
   expect(commandConvert('$test1/$test2/$test3')).toBe('$test1/$test2/$test3')
 })

--- a/src/command.test.js
+++ b/src/command.test.js
@@ -51,3 +51,9 @@ test(`
   isWindowsMock.__mock.returnValue = false
   expect(commandConvert('$test1/$test2/$test3')).toBe('$test1/$test2/$test3')
 })
+
+test(`converts braced unix-style env variable usage for windows`, () => {
+  isWindowsMock.__mock.returnValue = true
+  // eslint-disable-next-line no-template-curly-in-string
+  expect(commandConvert('${test}')).toBe('%test%')
+})


### PR DESCRIPTION
Hello [again](https://github.com/kentcdodds/cross-env/pull/85). :)

Now for the actual contribution I mentioned in #85. It turns out it supersedes #85, but I submitted #85 anyway because I thought it could still be useful for you to make a patch release, and you did, so that's great! This contribution however, is a breaking change.

If you feed cross-env on Windows with something like `echo $npm_package_name $npm_package_version`, it correctly runs `echo %npm_package_name% %npm_package_version%`. But if instead you feed it with `echo $npm_package_name/$npm_package_version` (notice the slash in the middle), then it runs `echo %npm_package_name%`. That is because the command argument is replaced by the converted *first* match of a variable pattern. The goal of this PR is to make cross-env support variables embedded inside arguments, so that it would instead run `echo %npm_package_name%/%npm_package_version%` (breaking change).

Supporting embedded variables means cross-env also needs to support braced variables on Unix (`${myvar}`), so this PR introduces that as well.

Let me know if you find this feature useful.