### PR TITLE
fix: Remove Windows => UNIX variable conversion

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -8,9 +8,9 @@ export default commandConvert
  * @returns {String} Converted command
  */
 function commandConvert(command) {
-  const envUseUnixRegex = /\$(\w+)|\${(\w+)}/g // $my_var or ${my_var}
-  const envUseWinRegex = /%(.*?)%/g // %my_var%
-  const isWin = isWindows()
-  const envExtract = isWin ? envUseUnixRegex : envUseWinRegex
-  return command.replace(envExtract, isWin ? '%$1$2%' : '$$$1')
+  if (!isWindows()) {
+    return command
+  }
+  const envUnixRegex = /\$(\w+)|\${(\w+)}/g // $my_var or ${my_var}
+  return command.replace(envUnixRegex, '%$1$2%')
 }

--- a/src/command.test.js
+++ b/src/command.test.js
@@ -14,9 +14,9 @@ test(`leaves command unchanged when not a variable`, () => {
   expect(commandConvert('test')).toBe('test')
 })
 
-test(`converts windows-style env variable usage for linux`, () => {
+test(`doesn't convert windows-style env variable`, () => {
   isWindowsMock.__mock.returnValue = false
-  expect(commandConvert('%test%')).toBe('$test')
+  expect(commandConvert('%test%')).toBe('%test%')
 })
 
 test(`leaves variable unchanged when using correct operating system`, () => {
@@ -38,18 +38,14 @@ test(`converts embedded unix-style env variables usage for windows`, () => {
   )
 })
 
-test(`converts embedded windows-style env variables usage for linux`, () => {
-  isWindowsMock.__mock.returnValue = false
-  expect(commandConvert('%test1%/%test2%/%test3%')).toBe(
-    '$test1/$test2/$test3',
-  )
-})
-
 // eslint-disable-next-line max-len
-test(`leaves embedded variables unchanged when using correct operating system`, () => {
-  isWindowsMock.__mock.returnValue = false
-  expect(commandConvert('$test1/$test2/$test3')).toBe('$test1/$test2/$test3')
-})
+test(
+  `leaves embedded variables unchanged when using correct operating system`,
+  () => {
+    isWindowsMock.__mock.returnValue = false
+    expect(commandConvert('$test1/$test2/$test3')).toBe('$test1/$test2/$test3')
+  },
+)
 
 test(`converts braced unix-style env variable usage for windows`, () => {
   isWindowsMock.__mock.returnValue = true


### PR DESCRIPTION
Before, Windows-style env variables (`%test%`) would be converted to UNIX-style format (`$test`) in UNIX
systems. That was an undocumented feature. I've removed that to simplify code a bit. Of course, UNIX
to Windows format still works, as that's the intended use of cross-env.

BREAKING CHANGE: `%windows_style%` env variables will no longer be converted to `$unix_style` in UNIX
machines. To fix it, use always the UNIX syntax, cross-env will change the format in Windows
machines as needed

As discussed in https://github.com/kentcdodds/cross-env/issues/90#issuecomment-286800030