### PR TITLE
JSON string tests and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ the parent. This is quite useful for launching the same command with different
 env variables or when the environment variables are too long to have everything
 in one line.
 
+Lastly, if you want to pass a JSON string (e.g., when using [ts-loader]), you can do as follows:
+```json
+{
+  "scripts": {
+    "test": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\"} node some_file.test.ts"
+  }
+}
+```
+Pay special attention to the **triple backslash** `(\\\)` **before** the **double quotes** `(")` and the **absence** of **single quotes** `(')`.
+Both of these conditions have to be met in order to work both on Windows and UNIX.
+
 ## `cross-env` vs `cross-env-shell`
 
 The `cross-env` module exposes two bins: `cross-env` and `cross-env-shell`. The
@@ -179,3 +190,4 @@ MIT
 [win-bash]: https://msdn.microsoft.com/en-us/commandline/wsl/about
 [angular-formly]: https://github.com/formly-js/angular-formly
 [cross-spawn]: https://www.npmjs.com/package/cross-spawn
+[ts-loader]: https://www.npmjs.com/package/ts-loader

--- a/src/variable.test.js
+++ b/src/variable.test.js
@@ -1,15 +1,19 @@
 import isWindowsMock from 'is-windows'
 import varValueConvert from './variable'
 
+const JSON_VALUE = '{\\"foo\\":\\"bar\\"}'
+
 beforeEach(() => {
   process.env.VAR1 = 'value1'
   process.env.VAR2 = 'value2'
+  process.env.JSON_VAR = JSON_VALUE
   isWindowsMock.__mock.reset()
 })
 
 afterEach(() => {
   delete process.env.VAR1
   delete process.env.VAR2
+  delete process.env.JSON_VAR
 })
 
 test(`doesn't affect simple variable values`, () => {
@@ -81,4 +85,14 @@ test(`resolves multiple env variable values`, () => {
 test(`resolves an env variable value for non-existant variable`, () => {
   isWindowsMock.__mock.returnValue = true
   expect(varValueConvert('foo-$VAR_POTATO')).toBe('foo-')
+})
+
+test(`resolves an env variable with a JSON string value on Windows`, () => {
+  isWindowsMock.__mock.returnValue = true
+  expect(varValueConvert('$JSON_VAR')).toBe(JSON_VALUE)
+})
+
+test(`resolves an env variable with a JSON string value on UNIX`, () => {
+  isWindowsMock.__mock.returnValue = false
+  expect(varValueConvert('$JSON_VAR')).toBe(JSON_VALUE)
 })


### PR DESCRIPTION
Added two tests that show the use the same JSON string on Windows and UNIX, despite not being totally sure that's how it's done. Would it be better to test against JSON.parse?

Also added a real example to the README.

I had to use the **--no-verify** flag, as **prettier-eslint** is messing up the **triple backslash** in the **tests**. What can I do to prevent that?

And just noticed that **travis** build is also **failing** precisely because of the triple backslash (**lint script**), despite the tests themselves running just fine.

Closes #30