### PR TITLE
fix: Do not pass function reference to `Array#map`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ function crossEnv(args, options = {}) {
       // run `path.normalize` for command(on windows)
       commandConvert(command, true),
       // by default normalize is `false`, so not run for cmd args
-      commandArgs.map(commandConvert),
+      commandArgs.map(arg => commandConvert(arg)),
       {
         stdio: 'inherit',
         shell: options.shell,


### PR DESCRIPTION
If a function reference is passed directly to `Array#map`, it is invoked with the array item,
index, and the array. Instead of passing the function reference, this invokes it explicitly with just the
array item. See
https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-fn-reference-in-iterator.md
