### PR TITLE
Remove env variables that don't exist from the converted commands in Windows.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 const jestConfig = require('kcd-scripts/config').jest
 
 jestConfig.coveragePathIgnorePatterns = jestConfig.coveragePathIgnorePatterns.concat(
-  ['/bin/'],
+  ['/bin/']
 )
 module.exports = jestConfig

--- a/src/__tests__/command.js
+++ b/src/__tests__/command.js
@@ -1,56 +1,63 @@
 import isWindowsMock from 'is-windows'
 import commandConvert from '../command'
 
+const env = {
+  test: 'a',
+  test1: 'b',
+  test2: 'c',
+  test3: 'd'
+}
+
 beforeEach(() => {
   isWindowsMock.__mock.reset()
 })
 
 test(`converts unix-style env variable usage for windows`, () => {
   isWindowsMock.__mock.returnValue = true
-  expect(commandConvert('$test')).toBe('%test%')
+  expect(commandConvert('$test', env)).toBe('%test%')
 })
 
 test(`leaves command unchanged when not a variable`, () => {
-  expect(commandConvert('test')).toBe('test')
+  expect(commandConvert('test', env)).toBe('test')
 })
 
 test(`doesn't convert windows-style env variable`, () => {
   isWindowsMock.__mock.returnValue = false
-  expect(commandConvert('%test%')).toBe('%test%')
+  expect(commandConvert('%test%', env)).toBe('%test%')
 })
 
 test(`leaves variable unchanged when using correct operating system`, () => {
   isWindowsMock.__mock.returnValue = false
-  expect(commandConvert('$test')).toBe('$test')
+  expect(commandConvert('$test', env)).toBe('$test')
 })
 
 test(`is stateless`, () => {
   // this test prevents falling into regexp traps like this:
   // http://stackoverflow.com/a/1520853/971592
   isWindowsMock.__mock.returnValue = true
-  expect(commandConvert('$test')).toBe(commandConvert('$test'))
+  expect(commandConvert('$test', env)).toBe(commandConvert('$test', env))
 })
 
 test(`converts embedded unix-style env variables usage for windows`, () => {
   isWindowsMock.__mock.returnValue = true
-  expect(commandConvert('$test1/$test2/$test3')).toBe('%test1%/%test2%/%test3%')
+  expect(commandConvert('$test1/$test2/$test3', env)).toBe('%test1%/%test2%/%test3%')
 })
 
 // eslint-disable-next-line max-len
 test(`leaves embedded variables unchanged when using correct operating system`, () => {
   isWindowsMock.__mock.returnValue = false
-  expect(commandConvert('$test1/$test2/$test3')).toBe('$test1/$test2/$test3')
+  expect(commandConvert('$test1/$test2/$test3', env)).toBe('$test1/$test2/$test3')
 })
 
 test(`converts braced unix-style env variable usage for windows`, () => {
   isWindowsMock.__mock.returnValue = true
   // eslint-disable-next-line no-template-curly-in-string
-  expect(commandConvert('${test}')).toBe('%test%')
+  expect(commandConvert('${test}', env)).toBe('%test%')
 })
 
 test(`normalizes command on windows`, () => {
   isWindowsMock.__mock.returnValue = true
   // index.js calls `commandConvert` with `normalize` param
   // as `true` for command only
-  expect(commandConvert('./cmd.bat', true)).toBe('cmd.bat')
+  expect(commandConvert('./cmd.bat', env, true)).toBe('cmd.bat')
 })

--- a/src/__tests__/command.js
+++ b/src/__tests__/command.js
@@ -5,7 +5,8 @@ const env = {
   test: 'a',
   test1: 'b',
   test2: 'c',
-  test3: 'd'
+  test3: 'd',
+  empty_var: ''
 }
 
 beforeEach(() => {
@@ -53,6 +54,16 @@ test(`converts braced unix-style env variable usage for windows`, () => {
   isWindowsMock.__mock.returnValue = true
   // eslint-disable-next-line no-template-curly-in-string
   expect(commandConvert('${test}', env)).toBe('%test%')
+})
+
+test(`removes non-existent variables from the converted command`, () => {
+  isWindowsMock.__mock.returnValue = true
+  expect(commandConvert('$test1/$foo/$test2', env)).toBe('%test1%//%test2%')
+})
+
+test(`removes empty variables from the converted command`, () => {
+  isWindowsMock.__mock.returnValue = true
+  expect(commandConvert('$foo/$test/$empty_var', env)).toBe('/%test%/')
 })
 
 test(`normalizes command on windows`, () => {

--- a/src/__tests__/command.js
+++ b/src/__tests__/command.js
@@ -6,7 +6,7 @@ const env = {
   test1: 'b',
   test2: 'c',
   test3: 'd',
-  empty_var: ''
+  'empty_var': ''
 }
 
 beforeEach(() => {

--- a/src/command.js
+++ b/src/command.js
@@ -22,7 +22,7 @@ function commandConvert(command, env, normalize = false) {
     // so for example "echo %FOO%" will literally print the string "%FOO%", as
     // opposed to printing an empty string in UNIX. See kentcdodds/cross-env#145
     // If the env variable isn't defined at runtime, just strip it from the command entirely
-    return varName in env ? `%${varName}%` : ''
+    return env[varName] ? `%${varName}%` : ''
   })
   // Normalization is required for commands with relative paths
   // For example, `./cmd.bat`. See kentcdodds/cross-env#127

--- a/src/command.js
+++ b/src/command.js
@@ -6,16 +6,24 @@ export default commandConvert
 /**
  * Converts an environment variable usage to be appropriate for the current OS
  * @param {String} command Command to convert
+ * @param {Object} env Map of the current environment variable names and their values
  * @param {boolean} normalize If the command should be normalized using `path`
  * after converting
  * @returns {String} Converted command
  */
-function commandConvert(command, normalize = false) {
+function commandConvert(command, env, normalize = false) {
   if (!isWindows()) {
     return command
   }
   const envUnixRegex = /\$(\w+)|\${(\w+)}/g // $my_var or ${my_var}
-  const convertedCmd = command.replace(envUnixRegex, '%$1$2%')
+  const convertedCmd = command.replace(envUnixRegex, (match, $1, $2) => {
+    const varName = $1 || $2
+    // In Windows, non-existent variables are not replaced by the shell,
+    // so for example "echo %FOO%" will literally print the string "%FOO%", as
+    // opposed to printing an empty string in UNIX. See kentcdodds/cross-env#145
+    // If the env variable isn't defined at runtime, just strip it from the command entirely
+    return varName in env ? `%${varName}%` : ''
+  })
   // Normalization is required for commands with relative paths
   // For example, `./cmd.bat`. See kentcdodds/cross-env#127
   // However, it should not be done for command arguments.

--- a/src/index.js
+++ b/src/index.js
@@ -8,16 +8,17 @@ const envSetterRegex = /(\w+)=('(.*)'|"(.*)"|(.*))/
 
 function crossEnv(args, options = {}) {
   const [envSetters, command, commandArgs] = parseCommand(args)
+  const env = getEnvVars(envSetters)
   if (command) {
     const proc = spawn(
       // run `path.normalize` for command(on windows)
-      commandConvert(command, true),
+      commandConvert(command, env, true),
       // by default normalize is `false`, so not run for cmd args
-      commandArgs.map(arg => commandConvert(arg)),
+      commandArgs.map(arg => commandConvert(arg, env)),
       {
         stdio: 'inherit',
         shell: options.shell,
-        env: getEnvVars(envSetters),
+        env,
       },
     )
     process.on('SIGTERM', () => proc.kill('SIGTERM'))


### PR DESCRIPTION
Fixes https://github.com/kentcdodds/cross-env/issues/145, check it for more context.

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Remove env variables that don't exist from the converted commands in Windows.

<!-- Why are these changes necessary? -->
**Why**: In Windows, if a `%variable%` is not defined (or it's the empty string), the shell won't parse it, and instead it will interpret it as the literal `%variable%` string. In UNIX, an undefined or empty variable wuld be interpreted as an empty string.

<!-- How were these changes implemented? -->
**How**:  The entire `process.env` map that would be passed down to the child process is now also passed to the `commandConvert` function. While converting a env variable to the Windows format (`$var => %var%`), it's checked if it actually has any value, and if it isn't, it's ommitted entirely.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation `N/A`
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
