### PR TITLE
feat: add support for default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,20 @@ Lastly, if you want to pass a JSON string (e.g., when using [ts-loader]), you ca
 Pay special attention to the **triple backslash** `(\\\)` **before** the **double quotes** `(")` and the **absence** of **single quotes** `(')`.
 Both of these conditions have to be met in order to work both on Windows and UNIX.
 
+### Default value
+
+You can also use Bash-like syntax to assign default value to variables: `"FOO=${BAR:default value}"`.
+
+This is useful when you do not want to override existing environment variable. In following example, `NODE_ENV` will **always** be set to `production` (whatever is globally set), but `NODE_CONFIG_DIR` will be set **only** if it does not already exist:
+
+```json
+{
+  "scripts": {
+    "start": "cross-env NODE_CONFIG_DIR=${NODE_CONFIG_DIR:/data/config} NODE_ENV=production node server.js"
+  }
+}
+```
+
 ## `cross-env` vs `cross-env-shell`
 
 The `cross-env` module exposes two bins: `cross-env` and `cross-env-shell`. The

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -58,20 +58,32 @@ it(`should handle no value after the equals sign`, () => {
   testEnvSetting({FOO_ENV: ''}, 'FOO_ENV=')
 })
 
+it(`should use default value if not defined`, () => {
+  testEnvSetting({FOO_ENV: 'foo'}, 'FOO_ENV=${FOO_ENV:foo}') // eslint-disable-line no-template-curly-in-string
+})
+
+it(`should not set not-overridable value if defined`, () => {
+  process.env.FOO_ENV = 'bar'
+  testEnvSetting({FOO_ENV: 'bar'}, 'FOO_ENV=${FOO_ENV:foo}') // eslint-disable-line no-template-curly-in-string
+  delete process.env.FOO_ENV
+})
+
 it(`should handle quoted scripts`, () => {
   crossEnv(['GREETING=Hi', 'NAME=Joe', 'echo $GREETING && echo $NAME'], {
     shell: true,
   })
-  expect(
-    crossSpawnMock.spawn,
-  ).toHaveBeenCalledWith('echo $GREETING && echo $NAME', [], {
-    stdio: 'inherit',
-    shell: true,
-    env: Object.assign({}, process.env, {
-      GREETING: 'Hi',
-      NAME: 'Joe',
-    }),
-  })
+  expect(crossSpawnMock.spawn).toHaveBeenCalledWith(
+    'echo $GREETING && echo $NAME',
+    [],
+    {
+      stdio: 'inherit',
+      shell: true,
+      env: Object.assign({}, process.env, {
+        GREETING: 'Hi',
+        NAME: 'Joe',
+      }),
+    },
+  )
 })
 
 it(`should do nothing given no command`, () => {

--- a/src/__tests__/variable.js
+++ b/src/__tests__/variable.js
@@ -88,6 +88,16 @@ test(`resolves an env variable value for non-existant variable`, () => {
   expect(varValueConvert('foo-$VAR_POTATO')).toBe('foo-')
 })
 
+test(`resolves a non-existant env variable with default value`, () => {
+  isWindowsMock.__mock.returnValue = true
+  expect(varValueConvert('foo-${VAR_POTATO:bar}')).toBe('foo-bar') // eslint-disable-line no-template-curly-in-string
+})
+
+test(`resolves an existant env variable with default value`, () => {
+  isWindowsMock.__mock.returnValue = true
+  expect(varValueConvert('foo-${VAR1:bar}')).toBe('foo-value1') // eslint-disable-line no-template-curly-in-string
+})
+
 test(`resolves an env variable with a JSON string value on Windows`, () => {
   isWindowsMock.__mock.returnValue = true
   expect(varValueConvert('$JSON_VAR')).toBe(JSON_VALUE)

--- a/src/variable.js
+++ b/src/variable.js
@@ -40,20 +40,25 @@ function replaceListDelimiters(varValue, varName = '') {
  * @returns {String} Converted value
  */
 function resolveEnvVars(varValue) {
-  const envUnixRegex = /(\\*)(\$(\w+)|\${(\w+)})/g // $my_var or ${my_var} or \$my_var
-  return varValue.replace(
-    envUnixRegex,
-    (_, escapeChars, varNameWithDollarSign, varName, altVarName) => {
-      // do not replace things preceded by a odd number of \
-      if (escapeChars.length % 2 === 1) {
-        return varNameWithDollarSign
-      }
-      return (
-        escapeChars.substr(0, escapeChars.length / 2) +
-        (process.env[varName || altVarName] || '')
-      )
-    },
-  )
+  const envUnixRegex = /(\\*)(\$(\w+)|\${(\w+)(?::([^}]+))?})/g // $my_var or ${my_var} or \$my_var
+  return varValue.replace(envUnixRegex, (...match) => {
+    const [
+      ,
+      escapeChars,
+      varNameWithDollarSign,
+      varName,
+      altVarName,
+      defaultValue = '',
+    ] = match
+    // do not replace things preceded by a odd number of \
+    if (escapeChars.length % 2 === 1) {
+      return varNameWithDollarSign
+    }
+    return (
+      escapeChars.substr(0, escapeChars.length / 2) +
+      (process.env[varName || altVarName] || defaultValue)
+    )
+  })
 }
 
 /**


### PR DESCRIPTION
**What**:

Add support for default values in variable replacement (bash syntax `${VAR:default value}`)

**Why**:

The initial need was that I wanted to set an environment variable which does not override global process.env. At first I was going to pick `env-cmd` which does not override, but this variable is mixed with variables that MUST override global setting. I didn't want to mix two tools for that.

At first, I was planning a specific syntax like `FOO=var` does override, and `FOO:=var` does not override, but it would have broken the compatibility with standard shell variable syntaxes that `cross-env` nicely maintain. The closest method in standard existing syntaxes to do what I wanted is default values.

I updated README to clearly explain this use-case: ``cross-env VAR1=doesOverride VAR2=${VAR2:doesNotOverride} command``

**How**:

Just modified the variable replacement regexp to support this syntax.

**Checklist**:

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
- [ ] Added myself to contributors table
  - Nope: command failed with `Error: Cannot find module 'all-contributors-cli/cli'`
