### PR TITLE
Allow backslash

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -133,6 +133,21 @@ it(`should propagate kill signals`, () => {
   expect(crossSpawnMock.__mock.spawned.kill).toHaveBeenCalledWith('SIGBREAK')
 })
 
+it(`should keep backslashes`, () => {
+  isWindowsMock.__mock.returnValue = true
+  crossEnv(['echo', '\\\\\\\\someshare\\\\somefolder'])
+  expect(crossSpawnMock.spawn).toHaveBeenCalledWith(
+    'echo',
+    ['\\\\someshare\\somefolder'],
+    {
+      stdio: 'inherit',
+      env: Object.assign({}, process.env),
+    },
+  )
+  isWindowsMock.__mock.reset()
+})
+
+
 function testEnvSetting(expected, ...envSettings) {
   if (expected.APPDATA === 2) {
     // kill the APPDATA to test both is undefined

--- a/src/index.js
+++ b/src/index.js
@@ -58,9 +58,10 @@ function parseCommand(args) {
         // match "\'" or "'"
         // or match "\" if followed by [$"\] (lookahead)
         .map(a => {
-          const re = /(\\)?'|([\\])(?=[$"\\])/g
+          const re = /\\\\|(\\)?'|([\\])(?=[$"\\])/g
           // Eliminate all matches except for "\'" => "'"
           return a.replace(re, m => {
+            if (m === "\\\\") return "\\"
             if (m === "\\'") return "'"
             return ''
           })


### PR DESCRIPTION
see #167 

Not really sure what you want the solution to be.  Apparently you want cross-env to use backlash as an esapce character even though Windows itself does not do this. So, this patch lets esaped backslashes through so if you want to pass `\\someshare\somefolder` you'd have to pass `\\\\someshare\\somefolder` as the argument.

also i tried running `npm run add-contributor` but appearently it doesn't work at the moment

**What**:  allow backslashes through

<!-- Why are these changes necessary? -->
**Why**:  beacuse otherwise you can't pass backslash through and can not specify UNC paths

<!-- How were these changes implemented? -->
**How**:  adjust the regular expression related to backslashes

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [X] Tests
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

```
C:\Users\gregg\src\cross-env>npm run add-contributor

> cross-env@0.0.0-semantically-released add-contributor C:\Users\gregg\src\cross-env
> kcd-scripts contributors add

module.js:557
    throw err;
    ^

Error: Cannot find module 'all-contributors-cli/cli'
    at Function.Module._resolveFilename (module.js:555:15)
    at Function.resolve (internal/module.js:18:19)
    at Object.<anonymous> (C:\Users\gregg\src\cross-env\node_modules\kcd-scripts\dist\scripts\contributors.js:7:33)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
    at Function.Module._load (module.js:505:3)
    at Function.Module.runMain (module.js:701:10)
    at startup (bootstrap_node.js:190:16)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! cross-env@0.0.0-semantically-released add-contributor: `kcd-scripts contributors add`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the cross-env@0.0.0-semantically-released add-contributor script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\gregg\AppData\Roaming\npm-cache\_logs\2018-03-09T03_13_59_441Z-debug.log
```

