### PR TITLE
docs(README): list @naholyr/cross-env in Other Solutions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ much easier for Windows users.
 ## Other Solutions
 
 - [`env-cmd`](https://github.com/toddbluhm/env-cmd) - Reads environment variables from a file instead
+- [`@naholyr/cross-env`](https://www.npmjs.com/package/@naholyr/cross-env) - `cross-env` with support for setting default values
 
 ## Contributors
 


### PR DESCRIPTION
The PR lists [@naholyr/cross-env](https://www.npmjs.com/package/@naholyr/cross-env), a `cross-env` fork that supports setting default values, as requested [here](https://github.com/kentcdodds/cross-env/pull/157#issuecomment-367304017).

There is a second fork implementing the same feature, but with non-standard syntax:
https://www.npmjs.com/package/cross-env-default

ref #157, #170
