### PR TITLE
use Path environment variable instead of PATH on windows

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -108,6 +108,17 @@ test(`does nothing when given no command`, () => {
   expect(crossSpawnMock.spawn).toHaveBeenCalledTimes(0)
 })
 
+test(`use Path environment variable instead of PATH on windows`, () => {
+  isWindowsMock.mockReturnValue(true)
+  testEnvSetting(
+    {
+      ...(process.env.Path ? {} : {Path: `path1;${process.env.Path}`}), //Hack for git shell on windows
+      PATH: `path1;${process.env.Path}`,
+    },
+    'PATH=path1:$PATH',
+  )
+})
+
 test(`normalizes commands on windows`, () => {
   isWindowsMock.mockReturnValue(true)
   crossEnv(['./cmd.bat'])

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const {spawn} = require('cross-spawn')
 const commandConvert = require('./command')
 const varValueConvert = require('./variable')
+const isWindows = require('./is-windows')
 
 module.exports = crossEnv
 
@@ -91,5 +92,8 @@ function getEnvVars(envSetters) {
   Object.keys(envSetters).forEach(varName => {
     envVars[varName] = varValueConvert(envSetters[varName], varName)
   })
+  if (isWindows() && envVars.Path && envVars.PATH) {
+    envVars.Path = envVars.PATH
+  }
   return envVars
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Issue #216  
<!-- Why are these changes necessary? -->

**Why**:
Windows use 'Path' environment variable instead of 'PATH'
And if I try to update PATH environment variable in script for example 
PATH="../node_modules/.bin:$PATH"
this does not work

<!-- How were these changes implemented? -->

**How**:
I suggest very a simple fix
copy env.PATH to env.Path after processing on windows

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A] Documentation
- [ x] Tests
- [ x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
