### PR TITLE
remove duplicate of PATH environment variable on Windows

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -2,6 +2,7 @@ const crossSpawnMock = require('cross-spawn')
 const isWindowsMock = require('../is-windows')
 
 jest.mock('../is-windows')
+jest.mock('../patch-path')
 jest.mock('cross-spawn')
 
 const crossEnv = require('../')

--- a/src/__tests__/patch-path.js
+++ b/src/__tests__/patch-path.js
@@ -1,0 +1,22 @@
+const patchPathEnv = require('../patch-path')
+const isWindowsMock = require('../is-windows')
+
+jest.mock('../is-windows')
+
+beforeEach(() => {
+  isWindowsMock.mockReturnValue(true)
+})
+
+test(`remove duplicate of PATH variable if the current OS is Windows`, () => {
+  isWindowsMock.mockReturnValue(true)
+  const env = {PATH: 'path1', Path: 'path2'}
+  patchPathEnv(env)
+  expect(env).toStrictEqual({PATH: 'path1'})
+})
+
+test(`do nothing if the current OS is not Windows`, () => {
+  isWindowsMock.mockReturnValue(false)
+  const env = {PATH: 'path1', Path: 'path2'}
+  patchPathEnv(env)
+  expect(env).toStrictEqual({PATH: 'path1', Path: 'path2'})
+})

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,14 @@
 const {spawn} = require('cross-spawn')
 const commandConvert = require('./command')
 const varValueConvert = require('./variable')
+const patchPathEnv = require('./patch-path')
 
 module.exports = crossEnv
 
 const envSetterRegex = /(\w+)=('(.*)'|"(.*)"|(.*))/
 
 function crossEnv(args, options = {}) {
+  patchPathEnv(process.env)
   const [envSetters, command, commandArgs] = parseCommand(args)
   const env = getEnvVars(envSetters)
   if (command) {

--- a/src/patch-path.js
+++ b/src/patch-path.js
@@ -1,0 +1,9 @@
+const isWindows = require('./is-windows')
+
+module.exports = patchPathEnv
+
+function patchPathEnv(env) {
+  if (isWindows() && env.Path && env.PATH) {
+    delete env.Path
+  }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Issue #216  
<!-- Why are these changes necessary? -->

**Why**:
[On Windows operating systems, environment variables are case-insensitive.](https://nodejs.org/api/process.html#process_process_env)
However, if when you spawn a new process and pass the env with two variables (PATH and Path), in this new process process.env will contains both variables, and this breaks the subsequent logic.

[Npm](https://github.com/npm/npm-lifecycle/blob/latest/index.js#L37) has logic to set both Path and PATH (if exist) variables on Windows, and by default used Path on Windows.
But if I use cgwin terminal on Windows for example, process.env contains PATH. 

<!-- How were these changes implemented? -->

**How**:
I add patchPathEnv.js 
```
function patchPathEnv(env) {
  if (isWindows() && env.Path && env.PATH) {
    delete env.Path
  }
}
```
remove duplicate variable if both exists.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [N/A] Documentation
- [ x] Tests
- [ x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
