### PR TITLE
Fixed unexpected token syntax error when calling spawn.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ function crossEnv(args, options = {}) {
         stdio: 'inherit',
         shell: options.shell,
         env,
-      },
+      }
     )
     process.on('SIGTERM', () => proc.kill('SIGTERM'))
     process.on('SIGINT', () => proc.kill('SIGINT'))


### PR DESCRIPTION
**What**: Unexpected token syntax error

**Why**: Node 6

**How**: Magic

**Checklist**:

- [X] Documentation
- [X] Tests
- [X] Ready to be merged
